### PR TITLE
Fix directory tree recursion and root path display

### DIFF
--- a/tree2clip/cli.py
+++ b/tree2clip/cli.py
@@ -13,10 +13,10 @@ def generate_tree(root, prefix=""):
     count = len(entries)
     for i, entry in enumerate(entries):
         path = os.path.join(root, entry)
-        is_last = (i == count - 1)
+        is_last = i == count - 1
         connector = "└── " if is_last else "├── "
         lines.append(prefix + connector + entry)
-        if os.path.isdir(path):
+        if os.path.isdir(path) and not os.path.islink(path):
             extension = "    " if is_last else "│   "
             lines.extend(generate_tree(path, prefix + extension))
     return lines
@@ -88,7 +88,10 @@ def main():
     
     # Generate the directory tree
     tree_lines = generate_tree(target_dir)
-    tree_text = "\n".join([os.path.basename(target_dir)] + tree_lines)
+    root_name = os.path.basename(os.path.normpath(target_dir))
+    if not root_name:
+        root_name = os.sep
+    tree_text = "\n".join([root_name] + tree_lines)
     
     # Collect file contents
     if args.no_content:


### PR DESCRIPTION
## Summary
- avoid descending into symlinked directories when building tree
- correctly display root directory name when input path is '/'

## Testing
- `flake8`
- `python tree2clip/cli.py / --no-content` (large output truncated)


------
https://chatgpt.com/codex/tasks/task_e_68463f12d18083298b6382c76f9de023